### PR TITLE
fix: remove padding for td, th

### DIFF
--- a/destyle.css
+++ b/destyle.css
@@ -454,6 +454,7 @@ caption {
 
 td,
 th {
+  padding: 0;
   vertical-align: top;
 }
 


### PR DESCRIPTION
Fixes a left over padding for `th` and `td` elements.

![padding](https://user-images.githubusercontent.com/33468089/82128386-1bd76180-97bb-11ea-950e-f010bfa67f33.gif)

I was wondering, is there any reason for not resetting margin and padding in the universal selector for all elements? This would deduplicate a lot of code and prevent any other missed paddings and margins like this. I'd be happy to put up another PR and close this one. Just let me know.

EDIT: Uh, I was just trying destyle out with [html5-kitchen-sink](https://github.com/dbox/html5-kitchen-sink) and I found that `option` elements also have a padding... Might actually be a reason to move at least padding into the universal selector.

![paddingoption](https://user-images.githubusercontent.com/33468089/82128632-e16ec400-97bc-11ea-8e20-632a429d989d.gif)

Sorry, I should have put this in an issue instead. I was too optimistic that the `td` and `th` would be the only left over elements.