### PR TITLE
Add outline to form elements

### DIFF
--- a/destyle.css
+++ b/destyle.css
@@ -235,7 +235,6 @@ textarea {
   background: transparent;
   padding: 0;
   margin: 0;
-  outline: 0;
   border-radius: 0;
   text-align: inherit;
 }


### PR DESCRIPTION
If outline is not set for a form element, accessibility will be reduced.

I thought that outline is necessary for users who browse with a keyboard.